### PR TITLE
Include LICENSE and README.md in tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
There is currently no license file in the pypi tarball, so add a
manifest to have the existing files packaged in future releases.

Based on an equivalent change by Audrey Dutcher.

Signed-off-by: Andreas Färber <afaerber@suse.de>