### PR TITLE
feat: compatibility for python 3.10

### DIFF
--- a/cooldict.py
+++ b/cooldict.py
@@ -1,4 +1,9 @@
 import collections
+import sys
+# check for python 3.10 or above 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    # add the attribute mutable mapping to collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
 import itertools
 import logging
 import pickle


### PR DESCRIPTION
I have added support for python 3.10 versions or above.
because according to this [stackoverflow](https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping) answer.
> The attribute MutableMapping from the module collections got moved into collections.abc in python3.10.